### PR TITLE
Patch PersistentRoutes and RemoveNeighbor functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.2.1
+VERSION=1.2.2
 PACKAGES_DIR=compiled_packages
 
 all: test build

--- a/internal/neighbor/types.go
+++ b/internal/neighbor/types.go
@@ -10,6 +10,7 @@ type NeighborManager struct {
 	reachableNeighbors   []Neighbor
 	targetInterface      string
 	targetInterfaceIndex int
+	isShuttingDown       bool
 }
 
 type Neighbor struct {


### PR DESCRIPTION
This PR addresses and fixes potential race conditions and shutdown edge cases in PersistentRoutes(), RemoveNeighbor(), and Cleanup() within the NeighborManager. These issues could lead to inconsistent route state — such as routes being re-added after deletion — especially during shutdown or neighbor removal events.

✅ Changes Made
1. Graceful Shutdown Coordination
Added a new field: isShuttingDown bool in NeighborManager.

This flag is set to true in Cleanup() before any route deletions.

Background goroutines like PersistentRoutes() now check isShuttingDown at the start of each loop iteration and exit immediately if it's set.

2. PersistentRoutes() Safety Improvements
Previously, PersistentRoutes() could re-add routes during or after Cleanup() due to lack of coordination.

Now:

It locks NeighborManager.mu to check isShuttingDown.

If shutdown is in progress, it unlocks and exits the loop.

This ensures no route re-adding after cleanup starts.

3. RemoveNeighbor() Atomicity Fix
Previously, route deletion happened after releasing the lock that protects reachableNeighbors, allowing a race with PersistentRoutes().

Now:

The route is removed while still holding the mutex, ensuring atomic removal of both the neighbor and its route.

Prevents PersistentRoutes() from seeing and acting on a neighbor that’s in the process of being removed.

4. Cleanup() Lock Efficiency
Previously, Cleanup() held the lock (mu) while deleting each route, which could block the system.

Now:

* It sets isShuttingDown = true early while holding the lock.
* Then copies the neighbor list and releases the lock.
* Route deletion is performed outside the lock, ensuring better concurrency and system responsiveness.